### PR TITLE
add support for params in memory execution and stablize CreateSafeArray

### DIFF
--- a/appdomain.go
+++ b/appdomain.go
@@ -3,9 +3,10 @@
 package clr
 
 import (
-	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 type AppDomain struct {

--- a/examples/CLRWrapper/CLRWrapper.go
+++ b/examples/CLRWrapper/CLRWrapper.go
@@ -3,15 +3,16 @@
 package main
 
 import (
-	clr "github.com/ropnop/go-clr"
-	"log"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"runtime"
+
+	clr "github.com/ropnop/go-clr"
 )
 
 func main() {
-	fmt.Println("[+] Loading DLL from Disk")
+	/*fmt.Println("[+] Loading DLL from Disk")
 	ret, err := clr.ExecuteDLLFromDisk(
 		"TestDLL.dll",
 		"TestDLL.HelloWorld",
@@ -21,16 +22,15 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Printf("[+] DLL Return Code: %d\n", ret)
-
-	
+	*/
 	fmt.Println("[+] Executing EXE from memory")
-	exebytes, err := ioutil.ReadFile("helloworld.exe")
+	exebytes, err := ioutil.ReadFile(`C:\Users\ayoul3\Documents\go\reflect-pe\res\managed.exe`)
 	if err != nil {
 		log.Fatal(err)
 	}
 	runtime.KeepAlive(exebytes)
 
-	ret2, err := clr.ExecuteByteArray(exebytes)
+	ret2, err := clr.ExecuteByteArray(exebytes, []string{"test", "test2"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/CLRWrapper/CLRWrapper.go
+++ b/examples/CLRWrapper/CLRWrapper.go
@@ -24,7 +24,7 @@ func main() {
 	fmt.Printf("[+] DLL Return Code: %d\n", ret)
 
 	fmt.Println("[+] Executing EXE from memory")
-	exebytes, err := ioutil.ReadFile(`hellworld.exe`)
+	exebytes, err := ioutil.ReadFile("helloworld.exe")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/CLRWrapper/CLRWrapper.go
+++ b/examples/CLRWrapper/CLRWrapper.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	/*fmt.Println("[+] Loading DLL from Disk")
+	fmt.Println("[+] Loading DLL from Disk")
 	ret, err := clr.ExecuteDLLFromDisk(
 		"TestDLL.dll",
 		"TestDLL.HelloWorld",
@@ -22,9 +22,9 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Printf("[+] DLL Return Code: %d\n", ret)
-	*/
+
 	fmt.Println("[+] Executing EXE from memory")
-	exebytes, err := ioutil.ReadFile(`C:\Users\ayoul3\Documents\go\reflect-pe\res\managed.exe`)
+	exebytes, err := ioutil.ReadFile(`hellworld.exe`)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go-clr.go
+++ b/go-clr.go
@@ -106,7 +106,7 @@ func ExecuteDLLFromDisk(dllpath, typeName, methodName, argument string) (retCode
 
 // ExecuteByteArray is a wrapper function that will automatically load the latest supported framework into the current
 // process using the legacy APIs, then load and execute an executable from memory. It takes in a byte array of the
-// executable to load and run and returns the return code. It currently does not support any arguments on the entry point
+// executable to load and run and returns the return code. You can supply an array of strings as command line arguments.
 func ExecuteByteArray(rawBytes []byte, params []string) (retCode int32, err error) {
 	retCode = -1
 	metahost, err := GetICLRMetaHost()
@@ -175,9 +175,8 @@ func ExecuteByteArray(rawBytes []byte, params []string) (retCode int32, err erro
 	methodSignature := readUnicodeStr(unsafe.Pointer(methodSignaturePtr))
 
 	if expectsParams(methodSignature) {
-		paramPtr, err = PrepareParameters(params)
-		if err != nil {
-			return -1, err
+		if paramPtr, err = PrepareParameters(params); err != nil {
+			return
 		}
 	}
 

--- a/go-clr.go
+++ b/go-clr.go
@@ -201,6 +201,8 @@ func ExecuteByteArray(rawBytes []byte, params []string) (retCode int32, err erro
 
 }
 
+// PrepareParameters creates a safe array of strings (arguments) nested inside a Variant object, which is itself
+// appended to the final safe array
 func PrepareParameters(params []string) (uintptr, error) {
 	listStrSafeArrayPtr, err := CreateEmptySafeArray(0x0008, len(params)) // VT_BSTR
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/ropnop/go-clr
 
 go 1.13
 
-require golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
+require (
+	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
+	golang.org/x/text v0.3.3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/methodinfo.go
+++ b/methodinfo.go
@@ -117,6 +117,7 @@ func (obj *MethodInfo) Invoke_3(variantObj Variant, parameters uintptr, pRetVal 
 	return ret
 }
 
+// GetString returns a string version of the method's signature
 func (obj *MethodInfo) GetString(addr *uintptr) error {
 	ret, _, _ := syscall.Syscall(
 		obj.vtbl.get_ToString,

--- a/methodinfo.go
+++ b/methodinfo.go
@@ -3,9 +3,10 @@
 package clr
 
 import (
-	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // from mscorlib.tlh
@@ -108,10 +109,21 @@ func (obj *MethodInfo) Invoke_3(variantObj Variant, parameters uintptr, pRetVal 
 		4,
 		uintptr(unsafe.Pointer(obj)),
 		uintptr(unsafe.Pointer(&variantObj)),
-		0,
+		parameters,
 		uintptr(unsafe.Pointer(pRetVal)),
 		0,
 		0,
 	)
 	return ret
+}
+
+func (obj *MethodInfo) GetString(addr *uintptr) error {
+	ret, _, _ := syscall.Syscall(
+		obj.vtbl.get_ToString,
+		2,
+		uintptr(unsafe.Pointer(obj)),
+		uintptr(unsafe.Pointer(addr)),
+		0,
+	)
+	return checkOK(ret, "get_ToString")
 }

--- a/safearray.go
+++ b/safearray.go
@@ -30,8 +30,8 @@ type SafeArrayBound struct {
 	lLbound   int32
 }
 
-// CreateSafeArray is a wrapper function that takes in a Go byte array and creates a SafeArray by making two syscalls
-// and copying raw memory into the correct spot.
+// CreateSafeArray is a wrapper function that takes in a Go byte array and creates a SafeArray containing unsigned bytes
+// by making two syscalls and copying raw memory into the correct spot.
 func CreateSafeArray(rawBytes []byte) (unsafe.Pointer, error) {
 
 	saPtr, err := CreateEmptySafeArray(0x11, len(rawBytes)) // VT_UI1
@@ -53,6 +53,8 @@ func CreateSafeArray(rawBytes []byte) (unsafe.Pointer, error) {
 
 }
 
+// CreateEmptySafeArray is a wrapper function that takes an array type and a size and creates a safe array with corresponding
+// properties. It returns a pointer to that empty array.
 func CreateEmptySafeArray(arrayType int, size int) (unsafe.Pointer, error) {
 	modOleAuto := syscall.MustLoadDLL("OleAut32.dll")
 	procSafeArrayCreate := modOleAuto.MustFindProc("SafeArrayCreate")
@@ -75,6 +77,8 @@ func CreateEmptySafeArray(arrayType int, size int) (unsafe.Pointer, error) {
 
 }
 
+// SysAllocString converts a Go string to a BTSR string, that is a unicode string prefixed with its length.
+// It returns a pointer to the string's content.
 func SysAllocString(str string) (unsafe.Pointer, error) {
 	modOleAuto := syscall.MustLoadDLL("OleAut32.dll")
 	sysAllocString := modOleAuto.MustFindProc("SysAllocString")
@@ -88,6 +92,7 @@ func SysAllocString(str string) (unsafe.Pointer, error) {
 	return unsafe.Pointer(ret), nil
 }
 
+// SafeArrayPutElement pushes an element to the safe array at a given index
 func SafeArrayPutElement(array, btsr unsafe.Pointer, index int) (err error) {
 	modOleAuto := syscall.MustLoadDLL("OleAut32.dll")
 	safeArrayPutElement := modOleAuto.MustFindProc("SafeArrayPutElement")

--- a/utils.go
+++ b/utils.go
@@ -3,8 +3,15 @@
 package clr
 
 import (
+	"bytes"
 	"fmt"
 	"log"
+	"strings"
+	"unicode/utf16"
+	"unsafe"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
 
 const S_OK = 0x0
@@ -21,4 +28,30 @@ func must(err error) {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func utf16Le(s string) []byte {
+	enc := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewEncoder()
+	var buf bytes.Buffer
+	t := transform.NewWriter(&buf, enc)
+	t.Write([]byte(s))
+	return buf.Bytes()
+}
+
+func expectsParams(input string) bool {
+	return !strings.Contains(input, "Void Main()")
+}
+
+func readUnicodeStr(ptr unsafe.Pointer) string {
+	var byteVal uint16
+	out := make([]uint16, 0)
+	for i := 0; ; i++ {
+		byteVal = *(*uint16)(unsafe.Pointer(ptr))
+		if byteVal == 0x0000 {
+			break
+		}
+		out = append(out, byteVal)
+		ptr = unsafe.Pointer(uintptr(ptr) + 2)
+	}
+	return string(utf16.Decode(out))
 }


### PR DESCRIPTION
Hello,
Loved your blog post! I was looking for a CLR loading implem in Go. Yours spared many nights of working with COM objects :) I thank you for that !
I added support for parameters when executing in memory since you mentioned it in the blog post. I was also having trouble with CreateSafeArray, I think because the GC was messing with the dereferenced pointers. Anyway I proposed a fix that makes it much more stable.
This PR is just an FYI, please see to adapt the code to your style ;)

Cheers,